### PR TITLE
Uninstallation target for CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,3 +37,12 @@ install(FILES systemd/joycond.service DESTINATION /etc/systemd/system
 install(FILES systemd/joycond.conf DESTINATION /etc/modules-load.d
         PERMISSIONS OWNER_WRITE OWNER_READ GROUP_READ WORLD_READ
         )
+
+add_custom_target("uninstall" COMMENT "Uninstall installed files")
+add_custom_command(
+    TARGET "uninstall"
+    POST_BUILD
+    COMMENT "Uninstall files with install_manifest.txt"
+    COMMAND xargs rm -vf < install_manifest.txt || echo Nothing in
+            install_manifest.txt to be uninstalled!
+)

--- a/README.md
+++ b/README.md
@@ -9,6 +9,11 @@ hid-nintendo is currently in review on the linux-input mailing list. The most re
 4. `sudo make install`
 5. `sudo systemctl enable --now joycond`
 
+# Uninstallation
+
+1. `sudo systemctl disable --now joycond`
+2. `sudo make uninstall`
+
 # Usage
 When a joy-con or pro controller is connected via bluetooth or USB, the player LEDs should start blinking periodically. This signals that the controller is in pairing mode.
 


### PR DESCRIPTION
Why:
* Users are requesting uninstallation method
* https://github.com/DanielOgorchock/joycond/issues/93

This change addresses the need by:
* CMake target for uninstall
* An install_manifest.txt is used to revert changes
* Uninstall steps are described in README.md